### PR TITLE
MMBN6: Fixed a generation issue when both game version ROMs were not provided prior to generation

### DIFF
--- a/worlds/mmbn6/__init__.py
+++ b/worlds/mmbn6/__init__.py
@@ -1031,6 +1031,13 @@ class MMBN6World(World):
             if os.path.exists(rompath):
                 os.unlink(rompath)
 
+    @classmethod
+    def stage_assert_generate(cls, multiworld: "MultiWorld") -> None:
+        for world in multiworld.get_game_worlds("MegaMan Battle Network 6"):
+            rom_file = get_base_rom_path(game_version=world.options.game_version.current_key)
+            if not os.path.exists(rom_file):
+                raise FileNotFoundError(rom_file)
+
     def create_item(self, name: str) -> "Item":
         item = item_table[name]
         return MMBN6Item(item.itemName, item.progression, item.code, self.player)


### PR DESCRIPTION
## What is this fixing or adding?
Fixed a generation issue when both game version ROMs were not provided prior to generation.

## How was this tested?
Deleted both ROMs from Archipelago files, then re-ran generation. Did the same thing by installing new apworld onto 0.6.4 and running generation, then uploaded output to Archipelago website to host a multiworld and verified both versions were playable.

## If this makes graphical changes, please attach screenshots.
