### PR TITLE
MMBN6: Fixed generation issues

### DIFF
--- a/worlds/mmbn6/BN6RomUtils.py
+++ b/worlds/mmbn6/BN6RomUtils.py
@@ -99,11 +99,11 @@ def generate_text_bytes(message) -> bytearray:
     return bytearray(char_to_hex(c) for c in message)
 
 def char_to_hex(c) -> int:
-    if c in charDict:
+    if c in charDict and 0 <= charDict[c] <= 255:
         return charDict[c]
     else:
-        # If the character doesn't exist, return the star character
-        return 0xE4E5
+        # If the character doesn't exist, or is out of range for a single byte value, return the star character
+        return 0x25
 
 def generate_chip_get(chip, code, amt) -> bytearray:
     chip_bytes = int16_to_byte_list_le(chip)

--- a/worlds/mmbn6/Rom.py
+++ b/worlds/mmbn6/Rom.py
@@ -339,19 +339,33 @@ def get_base_rom_path(file_name: str = "", game_version: str = "") -> str:
     return file_name
 
 
-def get_base_rom_bytes(file_name: str = "") -> bytes:
-    base_rom_bytes = getattr(get_base_rom_bytes, "base_rom_bytes", None)
-    if not base_rom_bytes:
-        file_name = get_base_rom_path(file_name)
-        base_rom_bytes = bytes(open(file_name, "rb").read())
+def get_base_rom_bytes(file_name: str = "", game_version: str = "") -> bytes:
+    if game_version == "gregar":
+        base_rom_bytes = getattr(get_base_rom_bytes, "gregar_base_rom_bytes", None)
+        if not base_rom_bytes:
+            file_name = get_base_rom_path(file_name)
+            base_rom_bytes = bytes(open(file_name, "rb").read())
 
-        basemd5 = hashlib.md5()
-        basemd5.update(base_rom_bytes)
-        if CHECKSUM_GREG != basemd5.hexdigest() and CHECKSUM_FALZ != basemd5.hexdigest():
-            raise Exception('Supplied Base Rom does not match US GBA Gregar or US GBA Falzar Version.'
-                            'Please provide the correct ROM version')
+            basemd5 = hashlib.md5()
+            basemd5.update(base_rom_bytes)
+            if CHECKSUM_GREG != basemd5.hexdigest():
+                raise Exception('Supplied Base Rom does not match US GBA Gregar.'
+                                'Please provide the correct ROM version')
 
-        get_base_rom_bytes.base_rom_bytes = base_rom_bytes
+            get_base_rom_bytes.gregar_base_rom_bytes = base_rom_bytes
+    else:
+        base_rom_bytes = getattr(get_base_rom_bytes, "falzar_base_rom_bytes", None)
+        if not base_rom_bytes:
+            file_name = get_base_rom_path(file_name)
+            base_rom_bytes = bytes(open(file_name, "rb").read())
+
+            basemd5 = hashlib.md5()
+            basemd5.update(base_rom_bytes)
+            if CHECKSUM_GREG != basemd5.hexdigest() and CHECKSUM_FALZ != basemd5.hexdigest():
+                raise Exception('Supplied Base Rom does not match US GBA Falzar Version.'
+                                'Please provide the correct ROM version')
+
+            get_base_rom_bytes.falzar_base_rom_bytes = base_rom_bytes
     return base_rom_bytes
 
 
@@ -362,7 +376,7 @@ def get_patched_rom_bytes(file_name: str = "", game_version: str = "") -> bytes:
     Which should contain all changed text banks and assembly code
     """
     import pkgutil
-    base_rom_bytes = get_base_rom_bytes(file_name)
+    base_rom_bytes = get_base_rom_bytes(file_name, game_version)
     if game_version == "gregar":
         patch_bytes = pkgutil.get_data(__name__, "data/bn6g-ap-patch.bsdiff")
     else:


### PR DESCRIPTION
## What is this fixing or adding?
- Fixed issue where certain characters are not in the character dictionary, or have a value that can't be stored in a single byte. This was leading to generation failures if player names have characters that are considered invalid.
- Fixed generation errors with larger multiworlds. If generation was slow enough, and there were both Gregar and Falzar worlds being generated, the  `base_rom_bytes` attribute would be used, which could theoretically be the wrong version of the game, leading to generation failures.

## How was this tested?
Generated multiworld with 45 YAMLs, including multiple Gregar and Falzar worlds. Played a small bit of a seed to verify no obvious issues with playing.

## If this makes graphical changes, please attach screenshots.
